### PR TITLE
Close Toolhelp32Snapshot handle on ProcessIterator drop

### DIFF
--- a/src/external/win/process.rs
+++ b/src/external/win/process.rs
@@ -470,6 +470,14 @@ impl Iterator for ProcessIterator {
     }
 }
 
+impl Drop for ProcessIterator {
+    fn drop(&mut self) {
+        unsafe {
+            CloseHandle(self.h);
+        }
+    }
+}
+
 /// Tried to open process by name
 pub fn open_process_by_name(
     name: &str,


### PR DESCRIPTION
As per [WinAPI Documentation](https://learn.microsoft.com/en-us/windows/win32/api/tlhelp32/nf-tlhelp32-createtoolhelp32snapshot#remarks), CloseHandle must be called on the Toolhelp32Snapshot handle to destroy it