### PR TITLE
Implement macro for literal unicode strings

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,6 +24,7 @@ external = ["std"]
 [dependencies]
 memoffset = "0.6"
 bitflags = "1.3"
+obfstr = "0.4.3"
 
 [target.'cfg(unix)'.dependencies.libc]
 version = "0.2"

--- a/src/types/win/unicode.rs
+++ b/src/types/win/unicode.rs
@@ -103,11 +103,11 @@ impl UnicodeString {
 /// A literal Unicode string.
 #[macro_export]
 macro_rules! unicode_string {
-    ($str:literal) => {
+    ($str:expr) => {
         $crate::types::win::UnicodeString::new(
             ($str.len() * 2) as _,
             ($str.len() * 2) as _,
-            windows::w!($str).0,
+            obfstr::wide!($str).as_ptr() as _,
         )
     };
 }

--- a/tests/unicode.rs
+++ b/tests/unicode.rs
@@ -2,16 +2,11 @@ use memflex::{types::win::UnicodeString, unicode_string};
 
 #[test]
 fn test_unicode_macros() {
-    const UNICODE_STRING: UnicodeString = unicode_string!("Memflex Unicode String");
+    const TEST_STRING: &'static str = "Memflex Unicode String";
+    const UNICODE_STRING: UnicodeString = unicode_string!(TEST_STRING);
 
-    assert_eq!(UNICODE_STRING.len(), "Memflex Unicode String".len());
-    assert_eq!(
-        UNICODE_STRING.bytes_len(),
-        "Memflex Unicode String".len() * 2
-    );
+    assert_eq!(UNICODE_STRING.len(), TEST_STRING.len());
+    assert_eq!(UNICODE_STRING.bytes_len(), TEST_STRING.len() * 2);
 
-    assert_eq!(
-        unsafe { UNICODE_STRING.to_string() }.unwrap(),
-        "Memflex Unicode String"
-    );
+    assert_eq!(unsafe { UNICODE_STRING.to_string() }.unwrap(), TEST_STRING);
 }


### PR DESCRIPTION
Adds a `unicode_string` macro that converts an expression into a constant `UnicodeString` for ease of use. Depends on the `obfstr` crate for its `obfstr::wide!` macro.