### PR TITLE
Fix MfError::Errno for macos targets

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -31,7 +31,7 @@ version = "0.2"
 optional = true
 
 [target.'cfg(windows)'.dependencies.windows]
-version = "0.43"
+version = "0.54.0"
 optional = true
 features = [
     "Win32_System_Diagnostics_ToolHelp",

--- a/src/error.rs
+++ b/src/error.rs
@@ -32,7 +32,10 @@ impl MfError {
 
     #[cfg(all(unix, feature = "std"))]
     pub(crate) fn last<T>() -> Result<T> {
+        #[cfg(target_os = "linux")]
         unsafe { Err(MfError::Errno(*libc::__errno_location())) }
+        #[cfg(target_os = "macos")]
+        unsafe { Err(MfError::Errno(*libc::__error())) }
     }
 }
 

--- a/src/internal/win.rs
+++ b/src/internal/win.rs
@@ -57,12 +57,12 @@ pub fn modules() -> impl Iterator<Item = crate::types::ModuleInfoWithName> {
 
 /// Allocates new console.
 pub fn alloc_console() -> bool {
-    unsafe { AllocConsole().as_bool() }
+    unsafe { AllocConsole().is_ok() }
 }
 
 /// Frees the console.
 pub fn free_console() -> bool {
-    unsafe { FreeConsole().as_bool() }
+    unsafe { FreeConsole().is_ok() }
 }
 
 /// Frees the library and exits current thread.

--- a/src/types/win/linked.rs
+++ b/src/types/win/linked.rs
@@ -45,7 +45,7 @@ impl<const OFFSET: usize, T> ListEntry<OFFSET, T> {
     }
 
     /// Assuming `self` is a list head, iterate over immutable references to all items in the list.
-    pub unsafe fn iter<'r>(&self) -> impl Iterator<Item = &'r T> {
+    pub unsafe fn iter<'r>(&self) -> impl Iterator<Item = &'r T> where T: 'r {
         let last = self.prev.map(|v| v.as_ptr().cast_const());
         let mut current = last;
         core::iter::from_fn(move || unsafe {
@@ -60,7 +60,7 @@ impl<const OFFSET: usize, T> ListEntry<OFFSET, T> {
     }
 
     /// Assuming `self` is a list head, iterate over mutable references to all items in the list.
-    pub unsafe fn iter_mut<'r>(&mut self) -> impl Iterator<Item = &'r mut T> {
+    pub unsafe fn iter_mut<'r>(&mut self) -> impl Iterator<Item = &'r mut T> where T: 'r {
         let last = self.prev.map(|v| v.as_ptr());
         let mut current = last;
         core::iter::from_fn(move || unsafe {


### PR DESCRIPTION
Not much to add here, macos uses `libc::__error()` rather than `libc::__errno_location()` on linux.